### PR TITLE
refactor(*): add `node:` prefix to all imports of Node built-in modules

### DIFF
--- a/src/OutputController.js
+++ b/src/OutputController.js
@@ -1,6 +1,6 @@
-import { Console } from 'console';
-import { Writable as WritableStream } from 'stream';
-import { Duplex as DuplexStream } from 'stream';
+import { Console } from 'node:console';
+import { Writable as WritableStream } from 'node:stream';
+import { Duplex as DuplexStream } from 'node:stream';
 import Spinner from '@comandeer/cli-spinner';
 import consoleControlStrings from 'console-control-strings';
 

--- a/src/bundler.js
+++ b/src/bundler.js
@@ -1,6 +1,6 @@
-import { basename } from 'path';
-import { dirname } from 'path';
-import { resolve as resolvePath } from 'path';
+import { basename } from 'node:path';
+import { dirname } from 'node:path';
+import { resolve as resolvePath } from 'node:path';
 import { rollup } from 'rollup';
 import convertCJS from '@rollup/plugin-commonjs';
 import dts from 'rollup-plugin-dts';

--- a/src/packageParser.js
+++ b/src/packageParser.js
@@ -1,7 +1,7 @@
-import { access } from 'fs/promises';
-import { readFile } from 'fs/promises';
-import { extname } from 'path';
-import { join as joinPath } from 'path';
+import { access } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
+import { extname } from 'node:path';
+import { join as joinPath } from 'node:path';
 
 let globby;
 

--- a/tests/OutputController.js
+++ b/tests/OutputController.js
@@ -1,4 +1,4 @@
-import { Console } from 'console';
+import { Console } from 'node:console';
 import consoleControlStrings from 'console-control-strings';
 import createDummyStream from './__helpers__/createDummyStream.js';
 import OutputController from '../src/OutputController.js';

--- a/tests/__fixtures__/externalDepPackage/src/index.js
+++ b/tests/__fixtures__/externalDepPackage/src/index.js
@@ -1,3 +1,3 @@
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 
 resolve( __filename );

--- a/tests/__helpers__/bundleChecks.js
+++ b/tests/__helpers__/bundleChecks.js
@@ -1,7 +1,7 @@
-import { readFile } from 'fs/promises';
-import { access } from 'fs/promises';
-import { resolve as resolvePath } from 'path';
-import { extname as getFileExtension } from 'path';
+import { readFile } from 'node:fs/promises';
+import { access } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
+import { extname as getFileExtension } from 'node:path';
 import validateSourcemap from 'sourcemap-validator';
 
 const checkStrategies = {

--- a/tests/__helpers__/createDummyStream.js
+++ b/tests/__helpers__/createDummyStream.js
@@ -1,5 +1,5 @@
-import { Duplex as DuplexStream } from 'stream';
-import { Writable as WritableStream } from 'stream';
+import { Duplex as DuplexStream } from 'node:stream';
+import { Writable as WritableStream } from 'node:stream';
 
 function createDummyStream( {
 	type = 'writable',

--- a/tests/bundler.js
+++ b/tests/bundler.js
@@ -1,5 +1,5 @@
-import { readFile } from 'fs/promises';
-import { resolve as resolvePath } from 'path';
+import { readFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
 import removeArtifacts from './__helpers__/removeArtifacts.js';
 import { checkFiles } from './__helpers__/bundleChecks.js';
 import { checkBanner } from './__helpers__/bundleChecks.js';

--- a/tests/cli.js
+++ b/tests/cli.js
@@ -1,9 +1,9 @@
-import { resolve as resolvePath } from 'path';
-import { access } from 'fs/promises';
-import { mkdir } from 'fs/promises';
-import { writeFile } from 'fs/promises';
-import { exec } from 'child_process';
-import { promisify } from 'util';
+import { exec } from 'node:child_process';
+import { access } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
+import { writeFile } from 'node:fs/promises';
+import { resolve as resolvePath } from 'node:path';
+import { promisify } from 'node:util';
 import removeArtifacts from './__helpers__/removeArtifacts.js';
 import createFixtureTest from './__helpers__/createFixtureTest.js';
 

--- a/tests/packageParser.js
+++ b/tests/packageParser.js
@@ -1,5 +1,5 @@
-import { resolve as resolvePath } from 'path';
-import { sep as pathSeparator } from 'path';
+import { resolve as resolvePath } from 'node:path';
+import { sep as pathSeparator } from 'node:path';
 import mockFS from 'mock-fs';
 import packageParser from '../src/packageParser.js';
 import { deepClone } from './__helpers__/utils';


### PR DESCRIPTION
Closes #236.